### PR TITLE
avoid garbage on the display

### DIFF
--- a/give-me-a-sign/give_me_a_sign.py
+++ b/give-me-a-sign/give_me_a_sign.py
@@ -84,6 +84,7 @@ class GiveMeASign:  # pylint: disable=too-many-instance-attributes
 
         self.matrix = Matrix()
         self.display = self.matrix.display
+        self.display.root_group = None
 
         self._setup_buttons()
         self._setup_rtc()


### PR DESCRIPTION
Console out gets written to the display by default

set root_group to None as early as possible to stop garbage on the display