### PR TITLE
Improve Home Assistant autodiscovery reliability and semantics

### DIFF
--- a/give_me_a_sign/_version.py
+++ b/give_me_a_sign/_version.py
@@ -4,5 +4,5 @@
 
 """Package version metadata."""
 
-__version__ = "0.0.0+auto.0"
+__version__ = "0.0.1+auto.0"
 __repo__ = "https://github.com/romkey/give-me-a-sign.git"

--- a/give_me_a_sign/home_assistant.py
+++ b/give_me_a_sign/home_assistant.py
@@ -68,29 +68,30 @@ class HomeAssistant:
             "free_memory": {
                 "name": "Free Memory",
                 "value_template": "{{ (value_json.free_memory / 1024 / 1024) | round(2) }}",
-                "unit_of_measurement": "MB",
+                "unit_of_measurement": "MiB",
                 "device_class": "data_size",
+                "state_class": "measurement",
                 "icon": "mdi:memory",
             },
             "flash_free": {
                 "name": "Flash Free",
                 "value_template": "{{ (value_json.flash_free / 1024 / 1024) | round(2) }}",
-                "unit_of_measurement": "MB",
+                "unit_of_measurement": "MiB",
                 "device_class": "data_size",
+                "state_class": "measurement",
                 "icon": "mdi:harddisk",
             },
             "flash_size": {
                 "name": "Flash Size",
                 "value_template": "{{ (value_json.flash_size / 1024 / 1024) | round(2) }}",
-                "unit_of_measurement": "MB",
+                "unit_of_measurement": "MiB",
                 "device_class": "data_size",
+                "state_class": "measurement",
                 "icon": "mdi:harddisk",
             },
             "last_update": {
                 "name": "Last Update",
-                "value_template": (
-                    "{{ as_datetime(value_json.time_utc).isoformat() }}"
-                ),
+                "value_template": "{{ value_json.time_utc_iso }}",
                 "device_class": "timestamp",
                 "icon": "mdi:clock",
             },
@@ -98,6 +99,7 @@ class HomeAssistant:
                 "name": "Timezone Offset",
                 "value_template": "{{ (value_json.timezone_offset / 3600) | round(1) }}",
                 "unit_of_measurement": "hours",
+                "state_class": "measurement",
                 "icon": "mdi:clock-time-eight",
             },
             "time_utc": {
@@ -124,6 +126,7 @@ class HomeAssistant:
                 "value_template": "{{ value_json.wifi_rssi }}",
                 "unit_of_measurement": "dBm",
                 "device_class": "signal_strength",
+                "state_class": "measurement",
                 "icon": "mdi:wifi",
             },
             "wifi_ssid": {
@@ -151,6 +154,7 @@ class HomeAssistant:
                 "value_template": "{{ value_json.uptime | int }}",
                 "unit_of_measurement": "s",
                 "device_class": "duration",
+                "state_class": "measurement",
                 "icon": "mdi:clock",
             },
             "rtc_status": {
@@ -234,6 +238,8 @@ class HomeAssistant:
                 payload["unit_of_measurement"] = sensor_config["unit_of_measurement"]
             if "device_class" in sensor_config:
                 payload["device_class"] = sensor_config["device_class"]
+            if "state_class" in sensor_config:
+                payload["state_class"] = sensor_config["state_class"]
 
             autodiscovery_messages.append({"topic": topic, "payload": payload})
 
@@ -259,6 +265,8 @@ class HomeAssistant:
                 ]
             if "device_class" in diagnostic_config:
                 payload["device_class"] = diagnostic_config["device_class"]
+            if "state_class" in diagnostic_config:
+                payload["state_class"] = diagnostic_config["state_class"]
 
             autodiscovery_messages.append({"topic": topic, "payload": payload})
 
@@ -283,6 +291,10 @@ class HomeAssistant:
             # notify entity can't share the text entity's id
             notify_payload = dict(payload)
             notify_payload["unique_id"] = f"{self._device_id}_{text_key}_notify"
+            if text_key == "message":
+                # Home Assistant's notify service typically sends {"message": "..."}.
+                # Map that to the plain-text payload expected by this command topic.
+                notify_payload["command_template"] = "{{ value_json.message }}"
             autodiscovery_messages.append(
                 {"topic": topic_notify, "payload": notify_payload}
             )
@@ -359,7 +371,7 @@ class HomeAssistant:
             payload = json.dumps(message["payload"])
 
             # Publish with retain=True so Home Assistant can discover after restart
-            self._mqtt_client.publish(topic, payload, retain=True)
+            self._mqtt_client.publish(topic, payload, retain=True, qos=1)
 
         print(f"Published {len(advertisements)} autodiscovery messages")
 

--- a/give_me_a_sign/mqtt.py
+++ b/give_me_a_sign/mqtt.py
@@ -451,6 +451,10 @@ class SignMQTT:  # pylint: disable=too-many-instance-attributes
             if not isinstance(text, str):
                 text = str(text)
             data = {"text": text} if key == "message" else {"person": text}
+        elif key == "message" and isinstance(data, dict):
+            # HA notify payloads commonly use {"message": "..."}.
+            if "text" not in data and isinstance(data.get("message"), str):
+                data = {"text": data["message"]}
         elif data is None:
             self._app.logger.error(
                 f"server:store_data({key}) store_data failed: {message}"
@@ -474,9 +478,12 @@ class SignMQTT:  # pylint: disable=too-many-instance-attributes
         flash_size = flash[0] * flash[2]
         flash_free = flash[0] * flash[3]
 
+        now_utc = time.time()
+
         info = {
             "uptime": time.monotonic_ns() / 1e9,
-            "time_utc": time.time(),
+            "time_utc": now_utc,
+            "time_utc_iso": self._epoch_to_iso_utc(now_utc),
             "timezone_offset": self._app.clock.timezone_offset,
             "free_memory": gc.mem_free(),  # pylint: disable=no-member
             "flash_free": flash_free,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuitpython-give-me-a-sign"
-version = "0.0.0+auto.0"
+version = "0.0.1+auto.0"
 description = "CircuitPython application library for Give Me A Sign LED matrix displays"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -8,8 +8,11 @@ from give_me_a_sign.home_assistant import HomeAssistant
 
 
 class _DummyMQTT:
+    def __init__(self):
+        self.published = []
+
     def publish(self, *args, **kwargs):
-        pass
+        self.published.append({"args": args, "kwargs": kwargs})
 
 
 def _configs_by_topic(messages):
@@ -59,3 +62,37 @@ def test_autodiscovery_still_includes_reboot_and_display():
     ]
     assert display["command_topic"] == f"{base}/display/set"
     assert display["state_topic"] == f"{base}/display/state"
+
+
+def test_autodiscovery_uses_expected_sensor_metadata_and_notify_template():
+    base = "givemeasign/sign/aa_bb_cc_dd_ee_ff"
+    ha = HomeAssistant("aa:bb:cc:dd:ee:ff", _DummyMQTT(), base)
+    configs = _configs_by_topic(ha.create_autodiscovery_config())
+
+    free_memory = configs[
+        "homeassistant/sensor/givemeasign_aa_bb_cc_dd_ee_ff/free_memory/config"
+    ]
+    assert free_memory["unit_of_measurement"] == "MiB"
+    assert free_memory["state_class"] == "measurement"
+
+    last_update = configs[
+        "homeassistant/sensor/givemeasign_aa_bb_cc_dd_ee_ff/last_update/config"
+    ]
+    assert last_update["value_template"] == "{{ value_json.time_utc_iso }}"
+
+    notify_message = configs[
+        "homeassistant/notify/givemeasign_aa_bb_cc_dd_ee_ff/message/config"
+    ]
+    assert notify_message["command_template"] == "{{ value_json.message }}"
+
+
+def test_publish_advertisements_uses_retain_and_qos_1():
+    base = "givemeasign/sign/aa_bb_cc_dd_ee_ff"
+    mqtt = _DummyMQTT()
+    ha = HomeAssistant("aa:bb:cc:dd:ee:ff", mqtt, base)
+
+    ha.publish_advertisements()
+
+    assert mqtt.published
+    assert all(call["kwargs"].get("retain") is True for call in mqtt.published)
+    assert all(call["kwargs"].get("qos") == 1 for call in mqtt.published)

--- a/tests/test_store_data.py
+++ b/tests/test_store_data.py
@@ -64,6 +64,11 @@ def test_store_json_string_message(sign_mqtt):
     assert sign_mqtt._app.data.get_item("message") == {"text": "hello"}
 
 
+def test_store_message_dict_with_message_key(sign_mqtt):
+    sign_mqtt.store_data("message", '{"message": "notify text"}')
+    assert sign_mqtt._app.data.get_item("message") == {"text": "notify text"}
+
+
 def test_store_json_string_greet(sign_mqtt):
     sign_mqtt.store_data("greet", '"Jane D."')
     assert sign_mqtt._app.data.get_item("greet") == {"person": "Jane D."}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- improve Home Assistant MQTT autodiscovery payload quality and delivery reliability
- make notify/message ingestion more compatible with Home Assistant notify payload shapes
- bump package SemVer metadata to `0.0.1+auto.0`

## Changes
- publish all discovery config topics with `retain=True, qos=1`
- add richer sensor metadata:
  - `state_class: measurement` for relevant diagnostic/measurement sensors
  - `MiB` units for byte values converted by `1024 * 1024`
- make timestamp discovery less template-fragile by adding `time_utc_iso` diagnostics field and using it for the `last_update` timestamp sensor
- add notify entity command mapping for message notifications and harden MQTT store logic to accept `{"message": "..."}` payloads for the `message` endpoint

## Tests
- expanded Home Assistant discovery tests for:
  - state_class + unit metadata
  - notify command template
  - retained QoS1 config publication
- added MQTT payload test for `{"message": "..."}` message ingestion
- full suite run: `python3 -m pytest` (69 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4a86-61a3-7ba5-8493-6e39f9854878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4a86-61a3-7ba5-8493-6e39f9854878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

